### PR TITLE
Fix hardcoded log file path that breaks CI

### DIFF
--- a/lib/observability/log.py
+++ b/lib/observability/log.py
@@ -1,6 +1,7 @@
 import atexit
 import contextlib
 import logging
+import os
 
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
@@ -131,9 +132,12 @@ def configure_logging(
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 
-        # Add file handler to root logger
+        # Add file handler to root logger (use configurable path or default to ./app.log)
     root_logger = logging.getLogger()
-    file_handler = logging.FileHandler("/home/jingyi/PycharmProjects/strategy-tester/app.log")
+    log_dir = os.environ.get("LOG_DIR", ".")
+    log_file = os.path.join(log_dir, "app.log")
+    os.makedirs(log_dir, exist_ok=True)
+    file_handler = logging.FileHandler(log_file)
     file_formatter = logging.Formatter(log_format, datefmt=date_format)
     file_handler.setFormatter(file_formatter)
     root_logger.addHandler(file_handler)


### PR DESCRIPTION
## Summary

The log file path in `lib/observability/log.py` was hardcoded to `/home/jingyi/PycharmProjects/strategy-tester/app.log`, which doesn't exist in the CI environment. This caused tests to fail with `FileNotFoundError`.

## Changes

- Made the log directory configurable via `LOG_DIR` environment variable
- Default log directory is now the current working directory (`.`)
- Creates the log directory if it doesn't exist

## Fixes

- Fixes issue #13

## Testing

All 44 tests pass:
```
44 passed, 5 warnings in 1.69s
```

@jingyi-zhao-01 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4a2d2f4987c74539ae280043f8e8232e)